### PR TITLE
Initialize Bun + Hono + Preact skeleton

### DIFF
--- a/.bunfig.toml
+++ b/.bunfig.toml
@@ -1,0 +1,1 @@
+[default]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store
+data/*.db*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# thisweeks_integlal
+# Integral Practice App
+
+Minimal Bun + Hono + Preact skeleton for a learning application.
+
+## Development
+
+```
+bun run app/server/server.ts
+```
+
+The server listens on `PORT` (default 3000).
+
+## Scripts
+
+- `bun run app/scripts/seed.ts` – seed demo data
+- `bun test` – run tests
+- `bunx tsc --noEmit` – type check
+
+## Environment variables
+
+- `PORT` – server port (default 3000)
+- `DB_PATH` – SQLite database path (default `./data/app.db`)

--- a/app/public/favicon.svg
+++ b/app/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text x="10" y="70" font-size="70">∫</text></svg>

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/app/scripts/seed.ts
+++ b/app/scripts/seed.ts
@@ -1,0 +1,11 @@
+import { insertProblem } from '../server/db';
+
+insertProblem({
+  session_id: 'demo',
+  question_tex: 'x',
+  answer_tex: '1',
+  video_id: 'demo',
+  t_sec: 0,
+});
+
+console.log('seeded');

--- a/app/server/api.ts
+++ b/app/server/api.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono';
+import { problemInputSchema, solveInputSchema, watchlogSchema } from './schema';
+import { getProblems, insertProblem, insertSolve, updateWatchlog } from './db';
+
+export function createApi(clients: Set<any>) {
+  const api = new Hono();
+
+  api.get('/problems', (c) => {
+    const sessionId = c.req.query('session_id');
+    if (!sessionId) return c.json({ error: 'session_id required' }, 400);
+    const items = getProblems(sessionId);
+    return c.json({ items });
+  });
+
+  api.post('/problems', async (c) => {
+    const body = await c.req.json();
+    const parsed = problemInputSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: parsed.error.message }, 400);
+    const id = insertProblem(parsed.data);
+    const problem = { id, ...parsed.data, created_at: new Date().toISOString() };
+    for (const ws of clients) {
+      ws.send(JSON.stringify({ type: 'problem_added', problem }));
+    }
+    return c.json({ id }, 201);
+  });
+
+  api.put('/solve/:id', async (c) => {
+    const id = c.req.param('id');
+    const body = await c.req.json();
+    const parsed = solveInputSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: parsed.error.message }, 400);
+    insertSolve({ problem_id: id, ...parsed.data });
+    for (const ws of clients) {
+      ws.send(JSON.stringify({ type: 'problem_solved', id, correct: parsed.data.correct }));
+    }
+    return c.json({ updated: true });
+  });
+
+  api.put('/watchlog', async (c) => {
+    const body = await c.req.json();
+    const parsed = watchlogSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: parsed.error.message }, 400);
+    updateWatchlog(parsed.data);
+    for (const ws of clients) {
+      ws.send(JSON.stringify({ type: 'watchlog_updated', ...parsed.data }));
+    }
+    return c.json({ updated: true });
+  });
+
+  return api;
+}

--- a/app/server/db.ts
+++ b/app/server/db.ts
@@ -1,0 +1,82 @@
+import { Database } from 'bun:sqlite';
+
+export type Problem = {
+  id: string;
+  session_id: string;
+  question_tex: string;
+  answer_tex: string;
+  video_id: string;
+  t_sec: number;
+  created_at: string;
+};
+
+export type Solve = {
+  id: string;
+  problem_id: string;
+  user_answer_tex: string;
+  correct: number;
+  time_ms: number;
+  created_at: string;
+};
+
+const dbPath = process.env.DB_PATH || './data/app.db';
+export const db = new Database(dbPath);
+
+db.exec("PRAGMA journal_mode=WAL;");
+db.exec("PRAGMA synchronous=NORMAL;");
+
+db.exec(`CREATE TABLE IF NOT EXISTS problems(
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  question_tex TEXT NOT NULL,
+  answer_tex TEXT NOT NULL,
+  video_id TEXT NOT NULL,
+  t_sec INTEGER NOT NULL,
+  created_at TEXT DEFAULT (datetime('now'))
+);`);
+
+db.exec(`CREATE TABLE IF NOT EXISTS solves(
+  id TEXT PRIMARY KEY,
+  problem_id TEXT NOT NULL,
+  user_answer_tex TEXT NOT NULL,
+  correct INTEGER NOT NULL,
+  time_ms INTEGER NOT NULL,
+  created_at TEXT DEFAULT (datetime('now'))
+);`);
+
+db.exec(`CREATE TABLE IF NOT EXISTS watchlog(
+  session_id TEXT PRIMARY KEY,
+  video_id TEXT NOT NULL,
+  watched_percent INTEGER NOT NULL,
+  updated_at TEXT DEFAULT (datetime('now'))
+);`);
+
+export function getProblems(session_id: string, limit = 20): Problem[] {
+  const stmt = db.query<Problem, [string, number]>(
+    'SELECT * FROM problems WHERE session_id = ? ORDER BY created_at DESC LIMIT ?'
+  );
+  return stmt.all(session_id, limit);
+}
+
+export function insertProblem(p: Omit<Problem, 'id' | 'created_at'> & { id?: string }): string {
+  const id = p.id || crypto.randomUUID();
+  const stmt = db.prepare(
+    'INSERT INTO problems (id, session_id, question_tex, answer_tex, video_id, t_sec) VALUES (?,?,?,?,?,?)'
+  );
+  stmt.run(id, p.session_id, p.question_tex, p.answer_tex, p.video_id, p.t_sec);
+  return id;
+}
+
+export function insertSolve(s: { problem_id: string; user_answer_tex: string; correct: boolean; time_ms: number; }): string {
+  const id = crypto.randomUUID();
+  const stmt = db.prepare(
+    'INSERT INTO solves (id, problem_id, user_answer_tex, correct, time_ms) VALUES (?,?,?,?,?)'
+  );
+  stmt.run(id, s.problem_id, s.user_answer_tex, s.correct ? 1 : 0, s.time_ms);
+  return id;
+}
+
+export function updateWatchlog(entry: { session_id: string; video_id: string; watched_percent: number }): void {
+  const stmt = db.prepare("INSERT INTO watchlog (session_id, video_id, watched_percent) VALUES (?,?,?) ON CONFLICT(session_id) DO UPDATE SET watched_percent = excluded.watched_percent, updated_at = datetime('now')");
+  stmt.run(entry.session_id, entry.video_id, entry.watched_percent);
+}

--- a/app/server/schema.ts
+++ b/app/server/schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const problemInputSchema = z.object({
+  session_id: z.string(),
+  question_tex: z.string().min(1).max(2000),
+  answer_tex: z.string().min(1).max(2000),
+  video_id: z.string(),
+  t_sec: z.number().int(),
+});
+
+export const solveInputSchema = z.object({
+  user_answer_tex: z.string().min(1).max(2000),
+  correct: z.boolean(),
+  time_ms: z.number().int(),
+});
+
+export const watchlogSchema = z.object({
+  session_id: z.string(),
+  video_id: z.string(),
+  watched_percent: z.number().int().min(0).max(100),
+});

--- a/app/server/server.ts
+++ b/app/server/server.ts
@@ -1,0 +1,50 @@
+import { Hono } from 'hono';
+import { serveStatic } from 'hono/bun';
+import { render } from './ssr';
+import { htmlTemplate, cspHeader } from './templates';
+import { createApi } from './api';
+
+const clients = new Set<any>();
+const app = new Hono();
+
+app.use('*', async (c, next) => {
+  const start = performance.now();
+  await next();
+  const ms = Math.round(performance.now() - start);
+  console.log(JSON.stringify({ path: c.req.path, ms }));
+});
+
+app.get('/', (c) => {
+  const nonce = crypto.randomUUID().replace(/-/g, '');
+  const body = render();
+  c.header('Content-Type', 'text/html');
+  c.header('Content-Security-Policy', cspHeader(nonce));
+  return c.body(htmlTemplate(body, nonce));
+});
+
+app.route('/api', createApi(clients));
+
+(app.get as any)('/ws', (c: any) => c.text(''), {
+  websocket: {
+    open(ws: any) {
+      clients.add(ws);
+    },
+    message() {},
+    close(ws: any) {
+      clients.delete(ws);
+    },
+  },
+});
+
+// static files
+app.use('/styles.css', serveStatic({ path: './app/ui/styles.css' }));
+app.use('/client.ts', serveStatic({ path: './app/ui/client.ts' }));
+app.use('/islands/*', serveStatic({ root: './app/ui/islands', rewriteRequestPath: (p) => p.replace('/islands', '') }));
+app.use('/favicon.svg', serveStatic({ path: './app/public/favicon.svg' }));
+app.use('/robots.txt', serveStatic({ path: './app/public/robots.txt' }));
+
+const port = Number(process.env.PORT || 3000);
+
+export const server = Bun.serve({ fetch: app.fetch, port, websocket: { message() {} } });
+
+console.log(`Server listening on http://localhost:${port}`);

--- a/app/server/ssr.tsx
+++ b/app/server/ssr.tsx
@@ -1,0 +1,6 @@
+import { renderToString } from 'preact-render-to-string';
+import { App } from '../ui/app';
+
+export function render() {
+  return renderToString(<App />);
+}

--- a/app/server/templates.ts
+++ b/app/server/templates.ts
@@ -1,0 +1,7 @@
+export function htmlTemplate(body: string, nonce: string): string {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><link rel="stylesheet" href="/styles.css" /></head><body>${body}<script nonce="${nonce}" type="module" src="/client.ts"></script></body></html>`;
+}
+
+export function cspHeader(nonce: string): string {
+  return `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'; connect-src 'self'`;
+}

--- a/app/ui/app.tsx
+++ b/app/ui/app.tsx
@@ -1,0 +1,11 @@
+import { h } from 'preact';
+
+export function App() {
+  return (
+    <div>
+      <h1>Integral Practice</h1>
+      <div id="player-root"></div>
+      <div id="practice-root"></div>
+    </div>
+  );
+}

--- a/app/ui/client.ts
+++ b/app/ui/client.ts
@@ -1,0 +1,16 @@
+import { h, render } from 'preact';
+
+async function load() {
+  const playerRoot = document.getElementById('player-root');
+  if (playerRoot) {
+    const mod = await import('./islands/PlayerIsland.tsx');
+    render(h(mod.default, {}), playerRoot);
+  }
+  const practiceRoot = document.getElementById('practice-root');
+  if (practiceRoot) {
+    const mod = await import('./islands/PracticeIsland.tsx');
+    render(h(mod.default, {}), practiceRoot);
+  }
+}
+
+load();

--- a/app/ui/components/Badge.tsx
+++ b/app/ui/components/Badge.tsx
@@ -1,0 +1,6 @@
+import { h } from 'preact';
+import type { ComponentChildren } from 'preact';
+
+export function Badge({ children }: { children: ComponentChildren }) {
+  return <span class="badge">{children}</span>;
+}

--- a/app/ui/components/Table.tsx
+++ b/app/ui/components/Table.tsx
@@ -1,0 +1,6 @@
+import { h } from 'preact';
+import type { ComponentChildren } from 'preact';
+
+export function Table({ children }: { children: ComponentChildren }) {
+  return <table class="table">{children}</table>;
+}

--- a/app/ui/islands/PlayerIsland.tsx
+++ b/app/ui/islands/PlayerIsland.tsx
@@ -1,0 +1,11 @@
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default function PlayerIsland() {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <button onClick={() => setCount(count + 1)}>Play {count}</button>
+    </div>
+  );
+}

--- a/app/ui/islands/PracticeIsland.tsx
+++ b/app/ui/islands/PracticeIsland.tsx
@@ -1,0 +1,12 @@
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
+
+export default function PracticeIsland() {
+  const [answer, setAnswer] = useState('');
+  return (
+    <div>
+      <input value={answer} onInput={(e) => setAnswer((e.target as HTMLInputElement).value)} />
+      <button onClick={() => alert(answer)}>Submit</button>
+    </div>
+  );
+}

--- a/app/ui/styles.css
+++ b/app/ui/styles.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; margin: 0; padding: 1rem; }
+.table { border-collapse: collapse; }
+.badge { background: #eee; padding: 2px 4px; border-radius: 3px; }

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,52 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "thisweeks_integlal",
+      "dependencies": {
+        "@playwright/test": "^1.54.2",
+        "hono": "^4.9.0",
+        "preact": "^10.27.0",
+        "preact-render-to-string": "^6.5.13",
+        "zod": "^4.0.15",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.54.2", "", { "dependencies": { "playwright": "1.54.2" }, "bin": { "playwright": "cli.js" } }, "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA=="],
+
+    "@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
+
+    "@types/node": ["@types/node@24.2.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw=="],
+
+    "@types/react": ["@types/react@19.1.9", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA=="],
+
+    "bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "hono": ["hono@4.9.0", "", {}, "sha512-JAUc4Sqi3lhby2imRL/67LMcJFKiCu7ZKghM7iwvltVZzxEC5bVJCsAa4NTnSfmWGb+N2eOVtFE586R+K3fejA=="],
+
+    "playwright": ["playwright@1.54.2", "", { "dependencies": { "playwright-core": "1.54.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw=="],
+
+    "playwright-core": ["playwright-core@1.54.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA=="],
+
+    "preact": ["preact@10.27.0", "", {}, "sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.5.13", "", { "peerDependencies": { "preact": ">=10" } }, "sha512-iGPd+hKPMFKsfpR2vL4kJ6ZPcFIoWZEcBf0Dpm3zOpdVvj77aY8RlLiQji5OMrngEyaxGogeakTb54uS2FvA6w=="],
+
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+
+    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
+    "zod": ["zod@4.0.15", "", {}, "sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "thisweeks_integlal",
+  "module": "app/server/server.ts",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "bun run app/server/server.ts",
+    "seed": "bun run app/scripts/seed.ts",
+    "test": "bun test",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.54.2",
+    "hono": "^4.9.0",
+    "preact": "^10.27.0",
+    "preact-render-to-string": "^6.5.13",
+    "zod": "^4.0.15"
+  }
+}

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,11 @@
+import { test, expect, afterAll } from 'bun:test';
+import { server } from '../app/server/server';
+
+const base = `http://localhost:${server.port}`;
+
+afterAll(() => server.stop());
+
+test('GET /', async () => {
+  const res = await fetch(base + '/');
+  expect(res.status).toBe(200);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx","jsxImportSource": "preact",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Bun server using Hono with SSR and WebSocket endpoints
- set up SQLite DB with tables for problems, solves and watch logs
- add Preact islands and client loader for dynamic hydration

## Testing
- `bunx tsc --noEmit`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68956c98513c83299c7bd2018c870d53